### PR TITLE
feat: 방명록 말풍선 생성 및 드래그 기능 구현

### DIFF
--- a/app/atoms/appAtoms.ts
+++ b/app/atoms/appAtoms.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const orbitEnabledAtom = atom(true);

--- a/components/three/GradientPlane.tsx
+++ b/components/three/GradientPlane.tsx
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { useMemo } from 'react';
+
+const GradientPlane = () => {
+  const texture = useMemo(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 512;
+    canvas.height = 216;
+    const context = canvas.getContext('2d')!;
+    const gradient = context.createLinearGradient(0, 0, 0, 256);
+
+    // 위는 투명, 아래는 흰색
+    gradient.addColorStop(0, 'rgba(255, 255, 255, 0)');
+    gradient.addColorStop(0.5, 'rgba(255, 255, 255, 1)');
+    gradient.addColorStop(1, 'rgba(255, 255, 255, 1)');
+
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, 256, 256);
+
+    const canvas2 = document.createElement('canvas');
+    canvas2.width = 512;
+    canvas2.height = 256;
+    const context2 = canvas2.getContext('2d')!;
+    const gradient2 = context2.createLinearGradient(0, 256, 0, 0);
+
+    // 위는 흰색, 아래는 투명
+    gradient2.addColorStop(0, 'rgba(255, 255, 255, 0)');
+    gradient2.addColorStop(0.6, 'rgba(255, 255, 255, 1)');
+    gradient2.addColorStop(1, 'rgba(255, 255, 255, 1)');
+
+    context2.fillStyle = gradient2;
+    context2.fillRect(0, 0, 256, 256);
+
+    return [new THREE.CanvasTexture(canvas), new THREE.CanvasTexture(canvas2)];
+  }, []);
+
+  return (
+    <>
+      <mesh position={[7.5, 13.35, -7.33]} renderOrder={1}>
+        <planeGeometry args={[29, 3]} />
+        <meshBasicMaterial
+          map={texture[1]}
+          transparent={true}
+          toneMapped={false}
+        />
+      </mesh>
+      <mesh position={[7.5, 13.35, -7.36]} renderOrder={1}>
+        <planeGeometry args={[29, 3]} />
+        <meshBasicMaterial
+          map={texture[1]}
+          transparent={true}
+          toneMapped={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <mesh position={[7.5, 1.95, -7.33]} renderOrder={1}>
+        <planeGeometry args={[29, 3]} />
+        <meshBasicMaterial
+          map={texture[0]}
+          transparent={true}
+          toneMapped={false}
+        />
+      </mesh>
+      <mesh position={[7.5, 1.95, -7.36]} renderOrder={1}>
+        <planeGeometry args={[29, 3]} />
+        <meshBasicMaterial
+          map={texture[0]}
+          transparent={true}
+          toneMapped={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+    </>
+  );
+};
+
+export default GradientPlane;

--- a/components/three/Scene.tsx
+++ b/components/three/Scene.tsx
@@ -3,6 +3,7 @@ import { OrbitControls } from '@react-three/drei';
 import {
   Desk,
   Floor,
+  GradientPlane,
   Keyboard,
   Laptop,
   Monitor,
@@ -29,6 +30,8 @@ const Scene = () => {
       {/* Room */}
       <Wall position={[0, 7.35, -7.35]} rotation={[0, 0, 0]} />
       <SpeechBubbleList />
+      <GradientPlane />
+
       <Wall position={[-7.35, 7.35, 0]} rotation={[0, Math.PI / 2, 0]} />
       <Floor />
 

--- a/components/three/Scene.tsx
+++ b/components/three/Scene.tsx
@@ -6,11 +6,15 @@ import {
   Keyboard,
   Laptop,
   Monitor,
-  SpeechBubble,
+  SpeechBubbleList,
   Wall,
 } from '@/components/three';
+import { useAtomValue } from 'jotai';
+import { orbitEnabledAtom } from '@/app/atoms/appAtoms';
 
 const Scene = () => {
+  const orbitEnabled = useAtomValue(orbitEnabledAtom);
+
   return (
     <Canvas
       style={{ background: 'white' }}
@@ -24,7 +28,7 @@ const Scene = () => {
 
       {/* Room */}
       <Wall position={[0, 7.35, -7.35]} rotation={[0, 0, 0]} />
-      <SpeechBubble position={[6, 7, -7.35]} text='말풍선 텍스트 예시입니다' />
+      <SpeechBubbleList />
       <Wall position={[-7.35, 7.35, 0]} rotation={[0, Math.PI / 2, 0]} />
       <Floor />
 
@@ -42,7 +46,7 @@ const Scene = () => {
       <Laptop position={[2.4, 4.1, -0.6]} rotation={[0, -Math.PI / 6, 0]} />
 
       {/* Camera Controls */}
-      <OrbitControls makedefault target={[0, 4, 0]} />
+      <OrbitControls makedefault target={[0, 4, 0]} enabled={orbitEnabled} />
       <axesHelper args={[5]} />
     </Canvas>
   );

--- a/components/three/Scene.tsx
+++ b/components/three/Scene.tsx
@@ -6,6 +6,7 @@ import {
   Keyboard,
   Laptop,
   Monitor,
+  SpeechBubble,
   Wall,
 } from '@/components/three';
 
@@ -23,6 +24,7 @@ const Scene = () => {
 
       {/* Room */}
       <Wall position={[0, 7.35, -7.35]} rotation={[0, 0, 0]} />
+      <SpeechBubble position={[6, 7, -7.35]} text='말풍선 텍스트 예시입니다' />
       <Wall position={[-7.35, 7.35, 0]} rotation={[0, Math.PI / 2, 0]} />
       <Floor />
 

--- a/components/three/SpeechBubble.tsx
+++ b/components/three/SpeechBubble.tsx
@@ -1,7 +1,8 @@
 import * as THREE from 'three';
 import { Text } from '@react-three/drei';
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Vector3 } from '@/app/types/blog';
+import { useFrame } from '@react-three/fiber';
 
 interface SpeechBubbleProps {
   text: string;
@@ -9,6 +10,19 @@ interface SpeechBubbleProps {
 }
 
 const SpeechBubble = ({ text, position }: SpeechBubbleProps) => {
+  const groupRef = useRef<THREE.Group>(null);
+  const worldPositionY = useRef(0);
+  const [isShow, setIsShow] = useState(false);
+
+  useFrame(() => {
+    if (groupRef.current) {
+      const worldPosition = new THREE.Vector3();
+      groupRef.current.getWorldPosition(worldPosition);
+      worldPositionY.current = worldPosition.y;
+      setIsShow(worldPosition.y < 13 && worldPosition.y > 1);
+    }
+  });
+
   // 텍스트 길이에 따라 말풍선 길이 계산 (문자당 0.2)
   const textWidth = useMemo(() => {
     const textLength = text.length;
@@ -35,23 +49,25 @@ const SpeechBubble = ({ text, position }: SpeechBubbleProps) => {
   }, [textWidth]);
 
   return (
-    <group position={position}>
-      {/* 테두리 */}
-      <lineSegments position={[-textWidth / 2, 0.3, 0]}>
-        <edgesGeometry args={[new THREE.ShapeGeometry(shape)]} />
-        <lineBasicMaterial color='black' />
-      </lineSegments>
+    <group ref={groupRef} position={position}>
+      {isShow && (
+        <>
+          <lineSegments position={[-textWidth / 2, 0.8, 0]}>
+            <edgesGeometry args={[new THREE.ShapeGeometry(shape)]} />
+            <lineBasicMaterial color='black' />
+          </lineSegments>
 
-      {/* 텍스트 */}
-      <Text
-        position={[-textWidth / 2, 0.3, 0.01]}
-        fontSize={0.2}
-        color='black'
-        anchorX='center'
-        anchorY='middle'
-      >
-        {text}
-      </Text>
+          <Text
+            position={[-textWidth / 2, 0.8, 0.01]}
+            fontSize={0.2}
+            color='black'
+            anchorX='center'
+            anchorY='middle'
+          >
+            {text}
+          </Text>
+        </>
+      )}
     </group>
   );
 };

--- a/components/three/SpeechBubble.tsx
+++ b/components/three/SpeechBubble.tsx
@@ -1,0 +1,59 @@
+import * as THREE from 'three';
+import { Text } from '@react-three/drei';
+import { useMemo } from 'react';
+import { Vector3 } from '@/app/types/blog';
+
+interface SpeechBubbleProps {
+  text: string;
+  position: Vector3;
+}
+
+const SpeechBubble = ({ text, position }: SpeechBubbleProps) => {
+  // 텍스트 길이에 따라 말풍선 길이 계산 (문자당 0.2)
+  const textWidth = useMemo(() => {
+    const textLength = text.length;
+    return Math.max(1, textLength * 0.2);
+  }, [text]);
+
+  // 말풍선(본체 + 꼬리)
+  const shape = useMemo(() => {
+    const bubbleShape = new THREE.Shape();
+
+    // 말풍선 본체
+    bubbleShape.moveTo(-textWidth / 2, 0.5); // 왼쪽 위
+    bubbleShape.lineTo(textWidth / 2, 0.5); // 오른쪽 위
+    bubbleShape.lineTo(textWidth / 2, -0.3); // 오른쪽 아래
+
+    // 말꼬리
+    bubbleShape.lineTo(textWidth / 2 + 0.2, -0.5); // 꼬리 끝
+
+    // 말풍선 본체 이어짐
+    bubbleShape.lineTo(-textWidth / 2, -0.5); // 왼쪽 아래
+    bubbleShape.lineTo(-textWidth / 2, 0.5); // 닫기
+
+    return bubbleShape;
+  }, [textWidth]);
+
+  return (
+    <group position={position}>
+      {/* 테두리 */}
+      <lineSegments position={[-textWidth / 2, 0.3, 0]}>
+        <edgesGeometry args={[new THREE.ShapeGeometry(shape)]} />
+        <lineBasicMaterial color='black' />
+      </lineSegments>
+
+      {/* 텍스트 */}
+      <Text
+        position={[-textWidth / 2, 0.3, 0.01]}
+        fontSize={0.2}
+        color='black'
+        anchorX='center'
+        anchorY='middle'
+      >
+        {text}
+      </Text>
+    </group>
+  );
+};
+
+export default SpeechBubble;

--- a/components/three/SpeechBubbleList.tsx
+++ b/components/three/SpeechBubbleList.tsx
@@ -1,0 +1,63 @@
+import { useRef, useState } from 'react';
+import * as THREE from 'three';
+import { SpeechBubble } from '@/components/three';
+import { useSetAtom } from 'jotai';
+import { orbitEnabledAtom } from '@/app/atoms/appAtoms';
+import { ThreeEvent } from '@react-three/fiber';
+
+const SpeechBubbleList = () => {
+  const isDraggingRef = useRef(false);
+  const setOrbitEnabled = useSetAtom(orbitEnabledAtom);
+  const groupRef = useRef<THREE.Group>(null);
+  const [lastMouseY, setLastMouseY] = useState(0);
+  const messages = [
+    '안녕하세요!',
+    '안녕하세요! 안녕하세요!',
+    '안녕하세요! 안녕하세요!안녕하세요!',
+    '안녕하세요!',
+    '안녕하세요!안녕하세요!안녕하세요!안녕하세요!',
+    '안녕하세요!안녕하세요!',
+    '안녕하세요!',
+    '안녕하세요!안녕하세요!안녕하세요!안녕하세요!안녕하세요!',
+  ];
+
+  const onPointerDown = (event: ThreeEvent<PointerEvent>) => {
+    isDraggingRef.current = true;
+
+    setLastMouseY(event.clientY);
+    setOrbitEnabled(false); // OrbitControls 비활성화
+  };
+
+  const onPointerMove = (event: ThreeEvent<PointerEvent>) => {
+    if (isDraggingRef.current && groupRef.current) {
+      const deltaY = event.clientY - lastMouseY; // 마우스 이동 거리 계산
+      groupRef.current.position.y -= deltaY * 0.005; // 이동 거리만큼 그룹 위치 업데이트
+      setLastMouseY(event.clientY);
+      setOrbitEnabled(false); // OrbitControls 비활성화
+    }
+  };
+
+  const onPointerUp = () => {
+    isDraggingRef.current = false;
+    setOrbitEnabled(true); // OrbitControls 활성화
+  };
+
+  return (
+    <group
+      ref={groupRef}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      {messages.map((message, index) => (
+        <SpeechBubble
+          key={index}
+          text={message}
+          position={[6.5, index * 1.5, -7.35]}
+        />
+      ))}
+    </group>
+  );
+};
+
+export default SpeechBubbleList;

--- a/components/three/SpeechBubbleList.tsx
+++ b/components/three/SpeechBubbleList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { SpeechBubble } from '@/components/three';
 import { useSetAtom } from 'jotai';
@@ -31,9 +31,12 @@ const SpeechBubbleList = () => {
   const onPointerMove = (event: ThreeEvent<PointerEvent>) => {
     if (isDraggingRef.current && groupRef.current) {
       const deltaY = event.clientY - lastMouseY; // 마우스 이동 거리 계산
-      groupRef.current.position.y -= deltaY * 0.005; // 이동 거리만큼 그룹 위치 업데이트
-      setLastMouseY(event.clientY);
-      setOrbitEnabled(false); // OrbitControls 비활성화
+      // 마우스 계산 값이 튀는 경우 방지
+      if (Math.abs(deltaY) < 100) {
+        groupRef.current.position.y -= deltaY * 0.005; // 이동 거리만큼 그룹 위치 업데이트
+        setLastMouseY(event.clientY);
+        setOrbitEnabled(false); // OrbitControls 비활성화
+      }
     }
   };
 
@@ -41,6 +44,22 @@ const SpeechBubbleList = () => {
     isDraggingRef.current = false;
     setOrbitEnabled(true); // OrbitControls 활성화
   };
+
+  // 드래그 중 group 밖으로 포인터가 나간 뒤 마우스를 떼는 경우 드래그 off
+  useEffect(() => {
+    const handlePointerUp = () => {
+      if (isDraggingRef) {
+        isDraggingRef.current = false;
+        setOrbitEnabled(true); // OrbitControls 활성화
+      }
+    };
+
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isDraggingRef, setOrbitEnabled]);
 
   return (
     <group

--- a/components/three/SpeechBubbleList.tsx
+++ b/components/three/SpeechBubbleList.tsx
@@ -72,7 +72,7 @@ const SpeechBubbleList = () => {
         <SpeechBubble
           key={index}
           text={message}
-          position={[6.5, index * 1.5, -7.35]}
+          position={[6.5, 11 - index * 1.5, -7.35]}
         />
       ))}
     </group>

--- a/components/three/index.ts
+++ b/components/three/index.ts
@@ -7,6 +7,7 @@ import Monitor from '@/components/three/Monitor';
 import Scene from '@/components/three/Scene';
 import Screen from '@/components/three/Screen';
 import SpeechBubble from '@/components/three/SpeechBubble';
+import SpeechBubbleList from '@/components/three/SpeechBubbleList';
 import SubmitButton from '@/components/three/SubmitButton';
 import Wall from '@/components/three/Wall';
 
@@ -20,6 +21,7 @@ export {
   Scene,
   Screen,
   SpeechBubble,
+  SpeechBubbleList,
   SubmitButton,
   Wall,
 };

--- a/components/three/index.ts
+++ b/components/three/index.ts
@@ -1,5 +1,6 @@
 import Desk from '@/components/three/Desk';
 import Floor from '@/components/three/Floor';
+import GradientPlane from '@/components/three/GradientPlane';
 import Keyboard from '@/components/three/Keyboard';
 import Keycap from '@/components/three/Keycap';
 import Laptop from '@/components/three/Laptop';
@@ -14,6 +15,7 @@ import Wall from '@/components/three/Wall';
 export {
   Desk,
   Floor,
+  GradientPlane,
   Keyboard,
   Keycap,
   Laptop,

--- a/components/three/index.ts
+++ b/components/three/index.ts
@@ -6,6 +6,7 @@ import Laptop from '@/components/three/Laptop';
 import Monitor from '@/components/three/Monitor';
 import Scene from '@/components/three/Scene';
 import Screen from '@/components/three/Screen';
+import SpeechBubble from '@/components/three/SpeechBubble';
 import SubmitButton from '@/components/three/SubmitButton';
 import Wall from '@/components/three/Wall';
 
@@ -18,6 +19,7 @@ export {
   Monitor,
   Scene,
   Screen,
+  SpeechBubble,
   SubmitButton,
   Wall,
 };


### PR DESCRIPTION
## 어떤 기능인가요?

> 방명록 글을 공간의 벽에 말풍선으로 표현

## 작업 상세 내용

1. 말풍선 생성
- 사각형 + 삼각형으로 말풍선 본체와 꼬리를 합치려고 했으나, 선으로 표현하기에 제약이 있어 말풍선 전체 shape을 그리는 방향으로 진행
- 모니터 뒷쪽 벽면에 보이도록 배치

2. 드래그 기능 구현
- 목록 느낌을 줄 수 있도록 드래그하여 말풍선 위치 변경
- 드래그 하는 동안에는 카메라 회전되지 않도록 제어

3. 말풍선 경계 생성
- 벽면의 위아래 바깥으로 말풍선이 넘어가지 않도록 흰색+투명의 그라디언트 경계 생성
- 경계 지점까지 도달한 말풍선은 렌더링 하지 않도록 처리(투명하게 조절 시 상하단에서 스크롤이 가능)


## 스크린샷
![Jan-21-2025 02-04-07](https://github.com/user-attachments/assets/f7268946-a06b-4cb0-a48a-473ba2d07d84)


